### PR TITLE
releng - fix windows test failures

### DIFF
--- a/tools/c7n_left/c7n_left/providers/terraform/variables.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/variables.py
@@ -61,10 +61,11 @@ class VariableResolver:
 
     def _write_file_content(self, content, suffix=".tfvars"):
         fh = tempfile.NamedTemporaryFile(
-            dir=self.source_dir, prefix="c7n-left-", suffix=suffix, mode="w+"
+            dir=self.source_dir, prefix="c7n-left-", suffix=suffix, mode="w+", delete=False
         )
         fh.write(content)
         fh.flush()
+        fh.close()
         self.temp_files.append(fh)
         return fh
 
@@ -84,6 +85,7 @@ class VariableResolver:
         finally:
             for t in self.temp_files:
                 t.close()
+                os.unlink(t.name)
 
     def get_uninitialized_var_files(self):
         # functions that operate on unknown values will typically result in


### PR DESCRIPTION
- Leaving named tempfiles open seems to leave 0-byte files that throw errors on subsequent read. Instead use files that don't auto-delete on close, and move deletion to the cleanup phase.

- Environment variables get uppercased on Windows, so don't rely on lowercase environment overrides.

- Remove some assumptions about path separators.